### PR TITLE
feat: add protocol navigator rail

### DIFF
--- a/src/components/ProtocolNavigatorRail.vue
+++ b/src/components/ProtocolNavigatorRail.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts">
+import { computed } from "vue"
+import type { ProtocolAnchor } from "@/composables/useProtocolNavigator"
+
+const props = defineProps<{
+  anchors: ProtocolAnchor[]
+  activeAnchorId: string | null
+  hoveredAnchorId: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: "anchor-click", anchorId: string): void
+  (e: "anchor-hover", anchorId: string): void
+  (e: "anchor-leave"): void
+}>()
+
+const activeAnchor = computed(() =>
+  props.anchors.find((anchor) => anchor.id === props.activeAnchorId) ?? null,
+)
+
+const hoveredAnchor = computed(() =>
+  props.anchors.find((anchor) => anchor.id === props.hoveredAnchorId) ?? null,
+)
+
+function anchorStyle(anchor: ProtocolAnchor): Record<string, string> {
+  return {
+    top: `${(anchor.topRatio * 100).toFixed(3)}%`,
+  }
+}
+
+function previewStyle(anchor: ProtocolAnchor): Record<string, string> {
+  const top = `${(anchor.topRatio * 100).toFixed(3)}%`
+  return {
+    top: `clamp(44px, ${top}, calc(100% - 44px))`,
+  }
+}
+
+function kindLabel(anchor: ProtocolAnchor): string {
+  switch (anchor.kind) {
+    case "section":
+      return anchor.level <= 1 ? "Section" : "Subsection"
+    case "step":
+      return "Step"
+    case "check":
+      return "Check"
+    case "table":
+      return "Table"
+    case "quiz":
+      return "Quiz"
+    case "callout":
+      return "Callout"
+    default:
+      return "Anchor"
+  }
+}
+</script>
+
+<template>
+  <aside class="protocol-navigator-rail" aria-label="Protocol Navigator">
+    <div class="protocol-navigator-rail__track">
+      <button
+        v-for="anchor in anchors"
+        :key="anchor.id"
+        class="protocol-navigator-rail__tick"
+        :class="[
+          `protocol-navigator-rail__tick--${anchor.kind}`,
+          `protocol-navigator-rail__tick--level-${anchor.level}`,
+          `protocol-navigator-rail__tick--status-${anchor.status}`,
+          { 'is-active': anchor.id === activeAnchorId },
+        ]"
+        :style="anchorStyle(anchor)"
+        type="button"
+        :aria-label="`${kindLabel(anchor)}: ${anchor.title}`"
+        :title="`${kindLabel(anchor)}: ${anchor.title}`"
+        @click="emit('anchor-click', anchor.id)"
+        @mouseenter="emit('anchor-hover', anchor.id)"
+        @mouseleave="emit('anchor-leave')"
+        @focus="emit('anchor-hover', anchor.id)"
+        @blur="emit('anchor-leave')"
+      />
+
+      <div
+        v-if="activeAnchor"
+        class="protocol-navigator-rail__active-marker"
+        :style="anchorStyle(activeAnchor)"
+      />
+    </div>
+
+    <div
+      v-if="hoveredAnchor"
+      class="protocol-navigator-rail__preview"
+      :style="previewStyle(hoveredAnchor)"
+    >
+      <p class="protocol-navigator-rail__preview-kind">
+        {{ kindLabel(hoveredAnchor) }}
+      </p>
+      <p class="protocol-navigator-rail__preview-title">
+        {{ hoveredAnchor.title }}
+      </p>
+      <p v-if="hoveredAnchor.summary" class="protocol-navigator-rail__preview-summary">
+        {{ hoveredAnchor.summary }}
+      </p>
+    </div>
+  </aside>
+</template>
+
+<style scoped>
+.protocol-navigator-rail {
+  width: 34px;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  user-select: none;
+  overflow: visible;
+}
+
+.protocol-navigator-rail__track {
+  width: 18px;
+  height: min(76vh, 620px);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #f0f4f8 0%, #e6edf3 100%);
+  border: 1px solid #d6e0ea;
+  position: relative;
+}
+
+.protocol-navigator-rail__tick {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 11px;
+  height: 2px;
+  border: 0;
+  border-radius: 999px;
+  background: #6f7f8f;
+  cursor: pointer;
+  opacity: 0.65;
+  transition: opacity 120ms ease, transform 120ms ease, background-color 120ms ease;
+}
+
+.protocol-navigator-rail__tick:hover,
+.protocol-navigator-rail__tick:focus-visible {
+  opacity: 0.95;
+  transform: translate(-50%, -50%) scaleX(1.08);
+  outline: none;
+}
+
+.protocol-navigator-rail__tick--section {
+  width: 13px;
+}
+
+.protocol-navigator-rail__tick--step {
+  width: 10px;
+}
+
+.protocol-navigator-rail__tick--check,
+.protocol-navigator-rail__tick--table,
+.protocol-navigator-rail__tick--callout,
+.protocol-navigator-rail__tick--quiz {
+  width: 7px;
+}
+
+.protocol-navigator-rail__tick--status-completed {
+  background: #2f7d32;
+}
+
+.protocol-navigator-rail__tick--status-warning {
+  background: #b26a00;
+}
+
+.protocol-navigator-rail__tick--status-error {
+  background: #b42318;
+}
+
+.protocol-navigator-rail__tick.is-active {
+  opacity: 1;
+}
+
+.protocol-navigator-rail__active-marker {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 16px;
+  height: 6px;
+  border-radius: 999px;
+  background: #1f3f63;
+  box-shadow: 0 0 0 2px rgba(31, 63, 99, 0.16);
+  pointer-events: none;
+}
+
+.protocol-navigator-rail__preview {
+  position: absolute;
+  left: calc(100% + 12px);
+  transform: translateY(-50%);
+  width: 210px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid #d8e1ea;
+  background: #fbfdff;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.09);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.protocol-navigator-rail__preview-kind {
+  font-size: 11px;
+  line-height: 1.2;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #4f657a;
+  margin: 0;
+}
+
+.protocol-navigator-rail__preview-title {
+  margin: 4px 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #162236;
+  font-weight: 600;
+}
+
+.protocol-navigator-rail__preview-summary {
+  margin: 5px 0 0;
+  font-size: 11px;
+  line-height: 1.45;
+  color: #43576a;
+}
+</style>

--- a/src/composables/useProtocolNavigator.ts
+++ b/src/composables/useProtocolNavigator.ts
@@ -1,0 +1,451 @@
+import { nextTick, onBeforeUnmount, ref, watch, type Ref } from "vue"
+
+export type ProtocolAnchorKind = "section" | "step" | "check" | "table" | "quiz" | "callout"
+export type ProtocolAnchorStatus = "default" | "completed" | "warning" | "error"
+
+export interface ProtocolAnchor {
+  id: string
+  kind: ProtocolAnchorKind
+  level: number
+  title: string
+  summary?: string
+  status: ProtocolAnchorStatus
+  element: HTMLElement
+  topRatio: number
+}
+
+interface UseProtocolNavigatorOptions {
+  scrollContainerRef: Ref<HTMLElement | null>
+  contentRootRef: Ref<HTMLElement | null>
+  content: Ref<string>
+  enabled?: Ref<boolean>
+}
+
+const STEP_SELECTOR = `[data-aimd-type="step"], .aimd-rec-inline--step, .aimd-step-card-block`
+const CHECK_SELECTOR = `[data-aimd-type="check"], .aimd-rec-inline--check, .aimd-check-pill`
+const TABLE_SELECTOR = `[data-aimd-type="var_table"], .aimd-field--var-table`
+const IMPORTANT_CALLOUT_SELECTOR = [
+  ".aimd-callout.aimd-callout--important",
+  ".aimd-callout.aimd-callout--warning",
+  ".aimd-callout.aimd-callout--danger",
+  ".aimd-callout.aimd-callout--caution",
+  ".aimd-callout.aimd-callout--bug",
+].join(", ")
+
+const ANCHOR_SELECTOR = [
+  "h2",
+  "h3",
+  STEP_SELECTOR,
+  CHECK_SELECTOR,
+  TABLE_SELECTOR,
+  IMPORTANT_CALLOUT_SELECTOR,
+].join(", ")
+
+function clamp01(value: number): number {
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim()
+}
+
+function textFromSelector(element: HTMLElement, selector: string): string {
+  const node = element.querySelector<HTMLElement>(selector)
+  return normalizeText(node?.textContent)
+}
+
+function computeTopRatio(contentRoot: HTMLElement, element: HTMLElement): number {
+  const total = Math.max(contentRoot.scrollHeight - 1, 1)
+  const rootRect = contentRoot.getBoundingClientRect()
+  const elementRect = element.getBoundingClientRect()
+  const top = Math.max(0, elementRect.top - rootRect.top)
+  return clamp01(top / total)
+}
+
+function ensureAnchorId(element: HTMLElement, kind: ProtocolAnchorKind, index: number): string {
+  const dataId = normalizeText(element.getAttribute("data-protocol-anchor-id"))
+  if (dataId) return dataId
+
+  const existingId = normalizeText(element.id)
+  if (existingId) {
+    element.setAttribute("data-protocol-anchor-id", existingId)
+    return existingId
+  }
+
+  const base = normalizeText(element.getAttribute("data-aimd-id"))
+    || normalizeText(element.getAttribute("data-aimd-step-card"))
+    || normalizeText(element.getAttribute("data-aimd-title"))
+    || normalizeText(element.textContent).toLowerCase().replace(/[^a-z0-9]+/g, "-")
+  const id = `${kind}-${base || index + 1}-${index + 1}`
+  element.setAttribute("data-protocol-anchor-id", id)
+  return id
+}
+
+function resolveCalloutStatus(element: HTMLElement): ProtocolAnchorStatus {
+  if (element.classList.contains("aimd-callout--danger") || element.classList.contains("aimd-callout--bug")) {
+    return "error"
+  }
+  return "warning"
+}
+
+function resolveStepTitle(element: HTMLElement): string {
+  const title = normalizeText(element.getAttribute("data-aimd-title"))
+    || textFromSelector(element, ".aimd-step-field__title")
+    || textFromSelector(element, ".aimd-step-field__main-meta .aimd-field__name")
+    || textFromSelector(element, ".aimd-rec-step-card__title")
+    || textFromSelector(element, ".aimd-field__name")
+    || textFromSelector(element, ".research-step__sequence")
+  return title || "Step"
+}
+
+function resolveCheckTitle(element: HTMLElement): string {
+  return textFromSelector(element, ".aimd-check-pill__label")
+    || textFromSelector(element, ".aimd-field__label")
+    || "Check"
+}
+
+function resolveTableTitle(element: HTMLElement): string {
+  return textFromSelector(element, ".aimd-field__name") || "Table"
+}
+
+function resolveCalloutTitle(element: HTMLElement): string {
+  return textFromSelector(element, ".aimd-callout__title-text")
+    || textFromSelector(element, ".aimd-callout__badge-label")
+    || "Callout"
+}
+
+function resolveCalloutSummary(element: HTMLElement): string | undefined {
+  const summary = textFromSelector(element, ".aimd-callout__body")
+  return summary ? summary.slice(0, 140) : undefined
+}
+
+function parseNumberAttribute(element: HTMLElement, attributeName: string): number | null {
+  const raw = element.getAttribute(attributeName)
+  if (!raw) return null
+  const parsed = Number.parseFloat(raw)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function formatDurationSummary(durationMs: number): string {
+  if (durationMs >= 60 * 60 * 1000) {
+    const hours = durationMs / (60 * 60 * 1000)
+    return `${hours % 1 === 0 ? hours.toFixed(0) : hours.toFixed(1)}h`
+  }
+  if (durationMs >= 60 * 1000) {
+    const minutes = durationMs / (60 * 1000)
+    return `${minutes % 1 === 0 ? minutes.toFixed(0) : minutes.toFixed(1)}m`
+  }
+  if (durationMs >= 1000) {
+    const seconds = durationMs / 1000
+    return `${seconds % 1 === 0 ? seconds.toFixed(0) : seconds.toFixed(1)}s`
+  }
+  return `${Math.round(durationMs)}ms`
+}
+
+function resolveStepStatus(element: HTMLElement): ProtocolAnchorStatus {
+  const checkbox = element.querySelector<HTMLInputElement>('input[type="checkbox"]')
+  if (checkbox?.checked) {
+    return "completed"
+  }
+
+  if (
+    element.querySelector(".aimd-step-timer__hero--overtime")
+    || element.querySelector(".aimd-step-timer__pill--error")
+    || element.querySelector(".aimd-rec-card__input--error")
+  ) {
+    return "error"
+  }
+
+  if (
+    element.querySelector(".aimd-step-timer__hero--warning")
+    || element.querySelector(".aimd-step-timer__hero--countdown")
+    || element.querySelector(".aimd-step-timer__pill--running")
+  ) {
+    return "warning"
+  }
+
+  return "default"
+}
+
+function resolveStepSummary(element: HTMLElement): string | undefined {
+  const summaryParts: string[] = []
+  const estimatedDurationMs = parseNumberAttribute(element, "data-aimd-estimated-duration-ms")
+  const timerMode = normalizeText(element.getAttribute("data-aimd-timer-mode"))
+
+  if (estimatedDurationMs && estimatedDurationMs > 0) {
+    summaryParts.push(`Estimate ${formatDurationSummary(estimatedDurationMs)}`)
+  }
+
+  if (timerMode) {
+    summaryParts.push(`Timer ${timerMode}`)
+  }
+
+  const liveTimerLabel = normalizeText(
+    textFromSelector(element, ".aimd-step-timer__hero")
+    || textFromSelector(element, ".aimd-step-timer__pill--actual")
+    || textFromSelector(element, ".aimd-step-timer__pill--estimate"),
+  )
+  if (liveTimerLabel) {
+    summaryParts.push(liveTimerLabel)
+  }
+
+  if (summaryParts.length === 0) {
+    const subtitle = normalizeText(element.getAttribute("data-aimd-subtitle"))
+    return subtitle || undefined
+  }
+
+  return summaryParts.join(" • ")
+}
+
+function extractProtocolAnchors(contentRoot: HTMLElement): ProtocolAnchor[] {
+  const candidates = Array.from(contentRoot.querySelectorAll<HTMLElement>(ANCHOR_SELECTOR))
+  const seen = new Set<HTMLElement>()
+  const anchors: ProtocolAnchor[] = []
+
+  candidates.forEach((element, index) => {
+    if (seen.has(element)) return
+    seen.add(element)
+
+    let kind: ProtocolAnchorKind | null = null
+    let level = 3
+    let title = ""
+    let summary: string | undefined
+    let status: ProtocolAnchorStatus = "default"
+
+    if (element.matches("h2, h3")) {
+      kind = "section"
+      level = element.tagName.toLowerCase() === "h2" ? 1 : 2
+      title = normalizeText(element.textContent)
+    } else if (element.matches(STEP_SELECTOR)) {
+      kind = "step"
+      level = 2
+      title = resolveStepTitle(element)
+      summary = resolveStepSummary(element)
+      status = resolveStepStatus(element)
+    } else if (element.matches(CHECK_SELECTOR)) {
+      kind = "check"
+      level = 3
+      title = resolveCheckTitle(element)
+      const checkedInput = element.querySelector<HTMLInputElement>('input[type="checkbox"]')
+      status = checkedInput?.checked ? "completed" : "default"
+    } else if (element.matches(TABLE_SELECTOR)) {
+      kind = "table"
+      level = 3
+      title = resolveTableTitle(element)
+      status = element.querySelector(".aimd-rec-card__input--error") ? "error" : "default"
+    } else if (element.matches(IMPORTANT_CALLOUT_SELECTOR)) {
+      kind = "callout"
+      level = 3
+      title = resolveCalloutTitle(element)
+      summary = resolveCalloutSummary(element)
+      status = resolveCalloutStatus(element)
+    }
+
+    if (!kind || !title) return
+
+    anchors.push({
+      id: ensureAnchorId(element, kind, index),
+      kind,
+      level,
+      title,
+      summary,
+      status,
+      element,
+      topRatio: computeTopRatio(contentRoot, element),
+    })
+  })
+
+  return anchors
+}
+
+function resolveActiveAnchorId(
+  scrollContainer: HTMLElement,
+  anchors: ProtocolAnchor[],
+): string | null {
+  if (anchors.length === 0) return null
+
+  const containerRect = scrollContainer.getBoundingClientRect()
+  const viewportTop = containerRect.top + 8
+  const viewportBottom = containerRect.bottom - 8
+  const targetY = containerRect.top + containerRect.height * 0.24
+
+  let bestId: string | null = anchors[0].id
+  let bestDistance = Number.POSITIVE_INFINITY
+
+  for (const anchor of anchors) {
+    const rect = anchor.element.getBoundingClientRect()
+    if (rect.height === 0) continue
+    if (rect.bottom < viewportTop || rect.top > viewportBottom) continue
+
+    const distance = Math.abs(rect.top - targetY)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      bestId = anchor.id
+    }
+  }
+
+  if (bestId) return bestId
+
+  const fallbackTop = scrollContainer.getBoundingClientRect().top + scrollContainer.clientHeight * 0.24
+  for (const anchor of anchors) {
+    if (anchor.element.getBoundingClientRect().top >= fallbackTop) {
+      return anchor.id
+    }
+  }
+
+  return anchors[anchors.length - 1]?.id ?? null
+}
+
+export function useProtocolNavigator(options: UseProtocolNavigatorOptions) {
+  const anchors = ref<ProtocolAnchor[]>([])
+  const activeAnchorId = ref<string | null>(null)
+  const hoveredAnchorId = ref<string | null>(null)
+
+  let intersectionObserver: IntersectionObserver | null = null
+  let refreshFrame: number | null = null
+
+  function disconnectIntersectionObserver() {
+    if (intersectionObserver) {
+      intersectionObserver.disconnect()
+      intersectionObserver = null
+    }
+  }
+
+  function updateActiveAnchorFromViewport() {
+    const scrollContainer = options.scrollContainerRef.value
+    if (!scrollContainer || anchors.value.length === 0) {
+      activeAnchorId.value = null
+      return
+    }
+    activeAnchorId.value = resolveActiveAnchorId(scrollContainer, anchors.value)
+  }
+
+  function connectIntersectionObserver() {
+    disconnectIntersectionObserver()
+
+    const scrollContainer = options.scrollContainerRef.value
+    if (!scrollContainer || anchors.value.length === 0) return
+
+    intersectionObserver = new IntersectionObserver(
+      () => {
+        updateActiveAnchorFromViewport()
+      },
+      {
+        root: scrollContainer,
+        rootMargin: "-20% 0px -68% 0px",
+        threshold: [0, 0.1, 0.25, 0.5, 0.75, 1],
+      },
+    )
+
+    anchors.value.forEach((anchor) => {
+      intersectionObserver?.observe(anchor.element)
+    })
+
+    updateActiveAnchorFromViewport()
+  }
+
+  function refreshAnchors() {
+    const contentRoot = options.contentRootRef.value
+    if (!contentRoot) {
+      anchors.value = []
+      activeAnchorId.value = null
+      disconnectIntersectionObserver()
+      return
+    }
+
+    anchors.value = extractProtocolAnchors(contentRoot)
+    connectIntersectionObserver()
+  }
+
+  function scheduleRefresh() {
+    if (refreshFrame !== null) return
+    refreshFrame = requestAnimationFrame(() => {
+      refreshFrame = null
+      refreshAnchors()
+    })
+  }
+
+  function scrollToAnchor(anchorId: string) {
+    const target = anchors.value.find((anchor) => anchor.id === anchorId)
+    if (!target) return
+    target.element.scrollIntoView({ behavior: "smooth", block: "start", inline: "nearest" })
+    activeAnchorId.value = target.id
+  }
+
+  function setHoveredAnchor(anchorId: string) {
+    hoveredAnchorId.value = anchorId
+  }
+
+  function clearHoveredAnchor() {
+    hoveredAnchorId.value = null
+  }
+
+  watch(
+    [() => options.enabled?.value ?? true, options.content],
+    ([enabled]) => {
+      if (!enabled) {
+        anchors.value = []
+        activeAnchorId.value = null
+        disconnectIntersectionObserver()
+        return
+      }
+      void nextTick(() => {
+        scheduleRefresh()
+      })
+    },
+    { immediate: true },
+  )
+
+  watch(
+    [options.scrollContainerRef, options.contentRootRef],
+    ([scrollContainer, contentRoot], _prev, onCleanup) => {
+      if (!scrollContainer || !contentRoot) return
+
+      const resizeObserver = new ResizeObserver(() => {
+        scheduleRefresh()
+      })
+      resizeObserver.observe(scrollContainer)
+      resizeObserver.observe(contentRoot)
+
+      const mutationObserver = new MutationObserver(() => {
+        scheduleRefresh()
+      })
+      mutationObserver.observe(contentRoot, {
+        subtree: true,
+        childList: true,
+        characterData: true,
+        attributes: true,
+      })
+
+      onCleanup(() => {
+        resizeObserver.disconnect()
+        mutationObserver.disconnect()
+      })
+
+      void nextTick(() => {
+        scheduleRefresh()
+      })
+    },
+    { immediate: true },
+  )
+
+  onBeforeUnmount(() => {
+    disconnectIntersectionObserver()
+    if (refreshFrame !== null) {
+      cancelAnimationFrame(refreshFrame)
+      refreshFrame = null
+    }
+  })
+
+  return {
+    anchors,
+    activeAnchorId,
+    hoveredAnchorId,
+    refreshAnchors,
+    scrollToAnchor,
+    setHoveredAnchor,
+    clearHoveredAnchor,
+  }
+}

--- a/src/pages/ProtocolView.vue
+++ b/src/pages/ProtocolView.vue
@@ -7,6 +7,8 @@ import { AimdRecorder, createEmptyProtocolRecordData } from "@airalogy/aimd-reco
 import "@airalogy/aimd-recorder/styles"
 import type { AimdProtocolRecordData } from "@airalogy/aimd-recorder"
 import { useWorkspaceStore } from "@/stores/workspace"
+import ProtocolNavigatorRail from "@/components/ProtocolNavigatorRail.vue"
+import { useProtocolNavigator } from "@/composables/useProtocolNavigator"
 import { invoke } from "@tauri-apps/api/core"
 
 const router = useRouter()
@@ -21,6 +23,8 @@ const files = ref<string[]>([])
 const selectedFile = ref<string | null>(null)
 const content = ref("")
 const record = ref<AimdProtocolRecordData>(createEmptyProtocolRecordData())
+const scrollContainerRef = ref<HTMLElement | null>(null)
+const protocolDocumentRef = ref<HTMLElement | null>(null)
 
 const protocolId = computed(() => route.query.id as string | undefined)
 
@@ -31,6 +35,21 @@ const protocol = computed(() =>
 const fileSelectOptions = computed(() =>
   files.value.map((f) => ({ label: f, value: f }))
 )
+
+const navigatorEnabled = computed(() => status.value === "ready")
+const {
+  anchors,
+  activeAnchorId,
+  hoveredAnchorId,
+  scrollToAnchor,
+  setHoveredAnchor,
+  clearHoveredAnchor,
+} = useProtocolNavigator({
+  scrollContainerRef,
+  contentRootRef: protocolDocumentRef,
+  content,
+  enabled: navigatorEnabled,
+})
 
 async function load() {
   if (!workspaceStore.current) {
@@ -155,8 +174,22 @@ watch(protocolId, (newId, oldId) => { if (newId !== oldId) load() })
         <NButton @click="openEditor">{{ t("editor.title") }}</NButton>
       </header>
 
-      <main class="protocol-content">
-        <AimdRecorder v-model="record" :content="content" locale="en-US" />
+      <main ref="scrollContainerRef" class="protocol-content">
+        <div class="protocol-layout">
+          <div ref="protocolDocumentRef" class="protocol-document">
+            <AimdRecorder v-model="record" :content="content" locale="en-US" />
+          </div>
+          <ProtocolNavigatorRail
+            v-if="anchors.length > 0"
+            class="protocol-navigator"
+            :anchors="anchors"
+            :active-anchor-id="activeAnchorId"
+            :hovered-anchor-id="hoveredAnchorId"
+            @anchor-click="scrollToAnchor"
+            @anchor-hover="setHoveredAnchor"
+            @anchor-leave="clearHoveredAnchor"
+          />
+        </div>
       </main>
     </template>
   </div>
@@ -200,5 +233,35 @@ watch(protocolId, (newId, oldId) => { if (newId !== oldId) load() })
 .protocol-content {
   flex: 1;
   overflow: auto;
+  padding: 16px 22px 24px;
+}
+
+.protocol-layout {
+  min-height: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1040px) 34px;
+  justify-content: center;
+  align-items: start;
+  column-gap: 14px;
+}
+
+.protocol-document {
+  min-width: 0;
+}
+
+.protocol-navigator {
+  position: sticky;
+  top: 16px;
+  align-self: start;
+}
+
+@media (max-width: 1024px) {
+  .protocol-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .protocol-navigator {
+    display: none;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- add a sticky Protocol Navigator rail to the protocol playback page
- derive section, step, check, table, and important callout anchors from the rendered protocol document
- add hover preview, click-to-jump navigation, and scroll-synced active state
- keep the hover preview absolutely positioned to avoid layout flicker
- make step anchor extraction compatible with upstream step timer metadata and DOM updates from airalogy/aimd commit be9bcae

## Testing
- launched the app with `pnpm tauri:dev` and verified the window starts normally
- manually checked navigator hover/click behavior in the protocol view
- `npm run type-check` is still blocked by an existing workspace resolution issue for `@airalogy/aimd-editor/vue`, unrelated to this PR